### PR TITLE
Removes complete=1 flag

### DIFF
--- a/routes/searchBarRoutes.js
+++ b/routes/searchBarRoutes.js
@@ -6,7 +6,7 @@ const endpoint = "https://api.labs.cognitive.microsoft.com/academic/v1.0";
 module.exports = app => {
   app.get("/api/searchBar/interpret/:query", async (req, res) => {
     const query = req.params.query;
-    const interpret_query = `${endpoint}/interpret?query=${query}&complete=1&count=1&subscription-key=${process.env.REACT_APP_MSCOG_KEY1}`;
+    const interpret_query = `${endpoint}/interpret?query=${query}&count=1&subscription-key=${process.env.REACT_APP_MSCOG_KEY1}`;
     const response = await axios(interpret_query);
     res.send(JSON.stringify(response.data));
   });


### PR DESCRIPTION
My theory is that passing the `complete=1` flag makes MS treat the query as a prefix, which means it can't find full matches.

I think removing this query param retains currently functionality and allows for exact searches.