### PR TITLE
removes exit transition effects on form

### DIFF
--- a/client/src/components/ReviewWizard/ReviewWizard.scss
+++ b/client/src/components/ReviewWizard/ReviewWizard.scss
@@ -150,17 +150,6 @@ $dynamic-text-area-min-height: 80px;
     transform: translate(0, 0);
     transition: all 250ms ease-in;
   }
-
-  .move-exit {
-    opacity: 1;
-    transform: translate(0, 0);
-  }
-
-  .move-exit-active {
-    opacity: 0.01;
-    transform: translate(-40px, 0);
-    transition: all 250ms ease-in;
-  }
 }
 .latex-demo {
   textarea {


### PR DESCRIPTION
Instead of removing transitions altogether, I just removed the exit animations
Enter animations have to work since the new field is always added at the bottom anyway

I also think adding is going to be way more common than deleting, so most users may not even realize the asymmetry. Still, if you think it'd be better to just get rid of all the animations, I won't object