### PR TITLE
moves google button popover to top

### DIFF
--- a/client/src/components/Login/Login.tsx
+++ b/client/src/components/Login/Login.tsx
@@ -73,7 +73,7 @@ export default function Login({ location }: LoginProps): Maybe<JSX.Element> {
                 content={LoginButton}
                 trigger="click"
                 visible={isModalOpen}
-                placement="bottom"
+                placement="top"
                 onVisibleChange={() => setIsModalOpen(!isModalOpen)}
               >
                 <Button shape="round" size="large" icon={<LoginOutlined />}>


### PR DESCRIPTION
@aradmargalit let's fight about this

For me, the UI experience of [click, scroll to show new button, click again] was stinky
Moving popover to top hides some of the graphics above, but doesn't require the scroll