### PR TITLE
fixes issue where DOI search would hang on 404

### DIFF
--- a/client/src/components/PaperSearchBar/PaperSearchBar-container.tsx
+++ b/client/src/components/PaperSearchBar/PaperSearchBar-container.tsx
@@ -13,8 +13,9 @@ const interpret = async (input: string): Promise<Paper[]> => {
   // second regex to delete single quotes, double quotes, and slashes
   query = query.replace(/['"/\\]/g, '');
 
-  const response = await axios.get<PaperResponse[]>(`api/searchBar/interpret/${query}`);
-  return response.data.map(constructPaperFromResponse);
+  const { data } = await axios.get<PaperResponse[]>(`api/searchBar/interpret/${query}`);
+
+  return data.map(constructPaperFromResponse);
 };
 
 const doiSearch = async (input: string): Promise<Paper[]> => {
@@ -28,8 +29,12 @@ const doiSearch = async (input: string): Promise<Paper[]> => {
     return [];
   }
 
-  const response = await axios.get<PaperResponse>(`/api/doi/${query}`);
-  return [constructPaperFromResponse(response.data)];
+  try {
+    const { data } = await axios.get<PaperResponse>(`/api/doi/${query}`);
+    return [constructPaperFromResponse(data)];
+  } catch (err) {
+    return [];
+  }
 };
 
 interface PaperSearchBarContainerProps {

--- a/server/src/routes/searchBarRoutes.ts
+++ b/server/src/routes/searchBarRoutes.ts
@@ -54,6 +54,7 @@ module.exports = (app: Application) => {
     // everything else in a field with key '0'. So we reconstruct the full url
     // from those two pieces.
     const fullQuery = `${req.params.query}${req.params['0']}`;
+
     try {
       const resp = await axios.get<string>(`https://doi.org/${fullQuery}`, {
         headers: { Accept: 'text/bibliography; style=bibtex' },


### PR DESCRIPTION
lil baby PR

When an invalid DOI was searched (like _10.1523/JNEUROSCI.17-06-02112.199_), the server would return 404, but front-end wouldn't catch it (and I guess just `await`ed indefinitely)

This fixes the issue