### PR TITLE
prevent image being too big

### DIFF
--- a/client/src/components/utils.tsx
+++ b/client/src/components/utils.tsx
@@ -131,6 +131,9 @@ export const wrapMarkdownWithMath = (markdownString: string): JSX.Element => {
     inlineMath: ({ value }) => <InlineMath math={value} />,
 
     math: ({ value }) => <BlockMath math={value} />,
+
+    // Prevent images from taking more than 90% of the preview box
+    image: ({ alt, src, title }) => <img alt={alt} src={src} title={title} style={{ maxWidth: '90%' }} />,
   };
 
   return (


### PR DESCRIPTION
Locks images at 90% of the box, so they don't spill over.