### PR TITLE
Fix Redux Test Setup

### DIFF
--- a/client/src/components/Drafts/Drafts.test.tsx
+++ b/client/src/components/Drafts/Drafts.test.tsx
@@ -3,11 +3,11 @@
 import { screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import userEvent from '@testing-library/user-event';
-import { RootState } from '../../slices';
 import { blankNotes, blankReview } from '../../templates';
 import { getBlankInitialState, renderWithRouterRedux } from '../../testUtils/reduxRender';
 import DraftsRedux from './Drafts-redux';
 import { suppressWarnings } from '../../testUtils/suppressWarnings';
+import { RootState } from '../../store';
 
 const mockGoBack = jest.fn();
 

--- a/client/src/store.ts
+++ b/client/src/store.ts
@@ -1,10 +1,12 @@
-import { configureStore } from '@reduxjs/toolkit';
+import { configureStore, ConfigureStoreOptions } from '@reduxjs/toolkit';
 import rootReducer from './slices';
 
-const store = configureStore({
+export const storeOptions: ConfigureStoreOptions = {
   reducer: rootReducer,
   middleware: (getDefaultMiddleware) => getDefaultMiddleware({ serializableCheck: false }),
-});
+};
+
+const store = configureStore(storeOptions);
 
 export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = typeof store.dispatch;

--- a/client/src/testUtils/reduxRender.tsx
+++ b/client/src/testUtils/reduxRender.tsx
@@ -3,10 +3,9 @@ import React from 'react';
 import { render, RenderResult } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { MemoryRouter, Route, Switch } from 'react-router-dom';
-import { applyMiddleware, createStore, Store } from 'redux';
-import thunk from 'redux-thunk';
-import { RootState } from '../store';
-import rootReducer from '../slices';
+import { Store } from 'redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { RootState, storeOptions } from '../store';
 
 interface RenderWithRouterReduxOptions {
   redirectTo?: string;
@@ -25,7 +24,10 @@ export function renderWithRouterRedux(
   {
     redirectTo,
     initialState,
-    store = createStore(rootReducer, initialState, applyMiddleware(thunk)),
+    store = configureStore({
+      ...storeOptions,
+      preloadedState: initialState,
+    }),
   }: RenderWithRouterReduxOptions = {}
 ): RenderWithRouterReduxResult {
   return {
@@ -47,7 +49,5 @@ export function renderWithRouterRedux(
 
 // Exported to help tests quickly get a blank initialState to work with
 export function getBlankInitialState(): RootState {
-  const store = createStore(rootReducer, applyMiddleware(thunk));
-
-  return store.getState();
+  return configureStore(storeOptions).getState();
 }


### PR DESCRIPTION
I wouldn't even really say this was broken, but it just makes the tests use the same setup as the application. Might be useful to make sure nothing ever breaks with options we pass to the store.