### PR TITLE
Kinder PPW indicator

### DIFF
--- a/client/src/colors.ts
+++ b/client/src/colors.ts
@@ -2,4 +2,3 @@ import { Color } from './types';
 
 export const darkGray: Color = '#222222';
 export const pawGreen: Color = '#237804';
-export const pawRed: Color = '#a8071a';

--- a/client/src/components/utils.tsx
+++ b/client/src/components/utils.tsx
@@ -11,7 +11,7 @@ import ReactMarkdown from 'react-markdown';
 
 import 'katex/dist/katex.min.css';
 import { Review } from '../types';
-import { darkGray, pawGreen, pawRed } from '../colors';
+import { darkGray, pawGreen } from '../colors';
 import NAText from './NAText';
 
 export const stringNotEmpty = (s: string): boolean => s !== '';
@@ -113,7 +113,7 @@ export const getReviewStats = (reviews: Review[]): ReviewStats => {
   const totalWeeks = moment().diff(sortedDates[0], 'days') / 7.0 || 1; // round up to 1 if totalWeeks === 0
   const ppw = sortedDates.length / totalWeeks;
   const ppwString = ppw.toFixed(2);
-  const ppwColor = ppw >= 0.99 ? pawGreen : pawRed;
+  const ppwColor = ppw >= 0.99 ? pawGreen : darkGray;
   const numReviews = reviews.length;
 
   return { numReviews, ppwString, ppwColor };


### PR DESCRIPTION
Instead of having a green papers per week (PPW) font color when above 1.0 ppw and red otherwise, replace the red with gray so it doesn't feel as judgmental.