### PR TITLE
fixes margin on home screen

### DIFF
--- a/client/src/components/Home/Home.scss
+++ b/client/src/components/Home/Home.scss
@@ -17,7 +17,8 @@
   transition: 0.3s;
   border-radius: 1em;
   padding: 1em;
-  margin: 1em 0;
+  margin-top: 1em;
+  margin-bottom: 1em;
 
   &:hover {
     box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.35);


### PR DESCRIPTION
TL;DR - when webpack builds for production, the _order_ of the combined stylesheets changes. In development, `antd` overrides `HomePage.scss` and sets a margin for the 1 column offset.

In production, the offset is overriden by the `margin: 1em 0`. So this PR just removes the part that sets horizontal margin to 0, so that antd can't be overridden.

Nasty little bug!