### PR TITLE
fix: no update after put

### DIFF
--- a/client/src/components/PaperSearchBar/PaperSearchBar-redux.tsx
+++ b/client/src/components/PaperSearchBar/PaperSearchBar-redux.tsx
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import React from 'react';
+import { constructPaperFromResponse, PaperResponse } from '../../dtos';
 import { useAppDispatch, useAppSelector } from '../../hooks/reduxHooks';
 import { setActiveReview } from '../../slices/activeReviewSlice';
 import { updateReadingList } from '../../slices/readingListSlice';
@@ -24,7 +25,10 @@ export default function PaperSearchBarRedux(): JSX.Element {
   const updateReadingListFunc = async (newReadingList: Paper[]): Promise<void> => {
     dispatch(updateReadingList(newReadingList));
 
-    await axios.put<Paper[]>('api/readingList', newReadingList);
+    const { data } = await axios.put<PaperResponse[]>('api/readingList', newReadingList);
+    if (data) {
+      dispatch(updateReadingList(data.map(constructPaperFromResponse)));
+    }
   };
 
   /**

--- a/client/src/components/PaperSearchBar/PaperSearchBar-redux.tsx
+++ b/client/src/components/PaperSearchBar/PaperSearchBar-redux.tsx
@@ -24,10 +24,7 @@ export default function PaperSearchBarRedux(): JSX.Element {
   const updateReadingListFunc = async (newReadingList: Paper[]): Promise<void> => {
     dispatch(updateReadingList(newReadingList));
 
-    const { data } = await axios.put<Paper[]>('api/readingList', newReadingList);
-    if (data) {
-      dispatch(updateReadingList(data));
-    }
+    await axios.put<Paper[]>('api/readingList', newReadingList);
   };
 
   /**


### PR DESCRIPTION
You get back a `PaperResponse[]` from the PUT, not a `Paper[]`. 

Turns out Typescript is only as smart as you let it be! Longer term, we should centralize this type of conversion in helpers to make this type of thing easier to catch.