### PR TITLE
Manual reading list add

### DIFF
--- a/client/src/components/Home/Home.test.tsx
+++ b/client/src/components/Home/Home.test.tsx
@@ -29,7 +29,7 @@ describe('<Home />', () => {
 
     it('has a reading list', () => {
       renderHome(initialAuthState);
-      expect(screen.getAllByText(/Reading List/)).toBeDefined();
+      expect(screen.getAllByText(/Reading List/)).toHaveLength(2);
     });
 
     it('has review list', () => {

--- a/client/src/components/Home/Home.test.tsx
+++ b/client/src/components/Home/Home.test.tsx
@@ -29,7 +29,7 @@ describe('<Home />', () => {
 
     it('has a reading list', () => {
       renderHome(initialAuthState);
-      expect(screen.getByText(/Reading List/)).toBeInTheDocument();
+      expect(screen.getAllByText(/Reading List/)).toBeDefined();
     });
 
     it('has review list', () => {

--- a/client/src/components/PaperSearchBar/PaperSearchBar-redux.tsx
+++ b/client/src/components/PaperSearchBar/PaperSearchBar-redux.tsx
@@ -1,34 +1,20 @@
-import axios from 'axios';
 import React from 'react';
-import { constructPaperFromResponse, PaperResponse } from '../../dtos';
 import { useAppDispatch, useAppSelector } from '../../hooks/reduxHooks';
 import { setActiveReview } from '../../slices/activeReviewSlice';
-import { updateReadingList } from '../../slices/readingListSlice';
 import { blankNotes, blankReview } from '../../templates';
 import { Paper, Review } from '../../types';
+import { useUpdateReadingListFunc } from '../ReadingList/hooks';
 import PaperSearchBarContainer from './PaperSearchBar-container';
 
 export default function PaperSearchBarRedux(): JSX.Element {
   const dispatch = useAppDispatch();
   const readingList = useAppSelector((state) => state.readingList);
-
+  const { updateReadingListFunc } = useUpdateReadingListFunc();
   /**
    * Sets the review in the redux store to be the default "blank" review, overwriting any existing review
    */
   const setBlankReview = (): void => {
     dispatch(setActiveReview(blankReview));
-  };
-
-  /**
-   * Updates reading list in redux store, PUTs it in the DB, then updates again using the response from the server (to correct any inconsistencies)
-   */
-  const updateReadingListFunc = async (newReadingList: Paper[]): Promise<void> => {
-    dispatch(updateReadingList(newReadingList));
-
-    const { data } = await axios.put<PaperResponse[]>('api/readingList', newReadingList);
-    if (data) {
-      dispatch(updateReadingList(data.map(constructPaperFromResponse)));
-    }
   };
 
   /**

--- a/client/src/components/PaperSearchBar/PaperSearchBar-redux.tsx
+++ b/client/src/components/PaperSearchBar/PaperSearchBar-redux.tsx
@@ -3,13 +3,13 @@ import { useAppDispatch, useAppSelector } from '../../hooks/reduxHooks';
 import { setActiveReview } from '../../slices/activeReviewSlice';
 import { blankNotes, blankReview } from '../../templates';
 import { Paper, Review } from '../../types';
-import { useUpdateReadingListFunc } from '../ReadingList/hooks';
+import { useSetReadingList } from '../ReadingList/hooks';
 import PaperSearchBarContainer from './PaperSearchBar-container';
 
 export default function PaperSearchBarRedux(): JSX.Element {
   const dispatch = useAppDispatch();
   const readingList = useAppSelector((state) => state.readingList);
-  const { updateReadingListFunc } = useUpdateReadingListFunc();
+  const { setReadingList } = useSetReadingList();
   /**
    * Sets the review in the redux store to be the default "blank" review, overwriting any existing review
    */
@@ -22,7 +22,7 @@ export default function PaperSearchBarRedux(): JSX.Element {
    */
   const handleReadingListAdd = (paper: Paper): void => {
     const newReadingList = readingList.concat(paper);
-    updateReadingListFunc(newReadingList);
+    setReadingList(newReadingList);
   };
 
   /**

--- a/client/src/components/ReadingList/ManualReadingListAdder.tsx
+++ b/client/src/components/ReadingList/ManualReadingListAdder.tsx
@@ -3,20 +3,35 @@ import { Button, Input } from 'antd';
 import React, { useState } from 'react';
 import { useAppSelector } from '../../hooks/reduxHooks';
 import { blankPaper } from '../../templates';
-import { useUpdateReadingListFunc } from './hooks';
+import { useSetReadingList } from './hooks';
+
+function ReadingListAdderForm({ onExit }: { onExit: VoidFunction }): JSX.Element {
+  const [title, setTitle] = useState('');
+
+  const readingList = useAppSelector((state) => state.readingList);
+  const { setReadingList } = useSetReadingList();
+
+  const submitItem = () => {
+    const newReadingList = readingList.concat({ ...blankPaper, title });
+    setReadingList(newReadingList);
+    onExit();
+  };
+
+  return (
+    <div className="reading-list-adder__form">
+      <Input placeholder="Paper title" value={title} onChange={(e) => setTitle(e.target.value)} />
+      <Button aria-label="submit" onClick={submitItem} disabled={title === ''}>
+        <CheckCircleOutlined />
+      </Button>
+      <Button aria-label="cancel" danger onClick={onExit}>
+        <CloseCircleOutlined />
+      </Button>
+    </div>
+  );
+}
 
 export default function ManualReadingListAdder(): JSX.Element {
   const [isEditing, setIsEditing] = useState(false);
-  const [title, setTitle] = useState('');
-  const readingList = useAppSelector((state) => state.readingList);
-
-  const { updateReadingListFunc } = useUpdateReadingListFunc();
-
-  const submitItem = () => {
-    setTitle('');
-    const newReadingList = readingList.concat({ ...blankPaper, title });
-    updateReadingListFunc(newReadingList);
-  };
 
   return (
     <div className="reading-list-adder">
@@ -25,15 +40,7 @@ export default function ManualReadingListAdder(): JSX.Element {
           Add to Reading List <PlusOutlined />
         </Button>
       ) : (
-        <div className="reading-list-adder__form">
-          <Input placeholder="Paper title" value={title} onChange={(e) => setTitle(e.target.value)} />
-          <Button aria-label="submit" onClick={submitItem} disabled={title === ''}>
-            <CheckCircleOutlined />
-          </Button>
-          <Button aria-label="cancel" danger onClick={() => setIsEditing(false)}>
-            <CloseCircleOutlined />
-          </Button>
-        </div>
+        <ReadingListAdderForm onExit={() => setIsEditing(false)} />
       )}
     </div>
   );

--- a/client/src/components/ReadingList/ManualReadingListAdder.tsx
+++ b/client/src/components/ReadingList/ManualReadingListAdder.tsx
@@ -27,10 +27,10 @@ export default function ManualReadingListAdder(): JSX.Element {
       ) : (
         <div className="reading-list-adder__form">
           <Input placeholder="Paper title" value={title} onChange={(e) => setTitle(e.target.value)} />
-          <Button onClick={submitItem} disabled={title === ''}>
+          <Button aria-label="submit" onClick={submitItem} disabled={title === ''}>
             <CheckCircleOutlined />
           </Button>
-          <Button danger onClick={() => setIsEditing(false)}>
+          <Button aria-label="cancel" danger onClick={() => setIsEditing(false)}>
             <CloseCircleOutlined />
           </Button>
         </div>

--- a/client/src/components/ReadingList/ManualReadingListAdder.tsx
+++ b/client/src/components/ReadingList/ManualReadingListAdder.tsx
@@ -1,13 +1,21 @@
 import { CheckCircleOutlined, CloseCircleOutlined, PlusOutlined } from '@ant-design/icons';
 import { Button, Input } from 'antd';
 import React, { useState } from 'react';
+import { useAppSelector } from '../../hooks/reduxHooks';
+import { blankPaper } from '../../templates';
+import { useUpdateReadingListFunc } from './hooks';
 
 export default function ManualReadingListAdder(): JSX.Element {
   const [isEditing, setIsEditing] = useState(false);
   const [title, setTitle] = useState('');
+  const readingList = useAppSelector((state) => state.readingList);
+
+  const { updateReadingListFunc } = useUpdateReadingListFunc();
 
   const submitItem = () => {
     setTitle('');
+    const newReadingList = readingList.concat({ ...blankPaper, title });
+    updateReadingListFunc(newReadingList);
   };
 
   return (

--- a/client/src/components/ReadingList/ManualReadingListAdder.tsx
+++ b/client/src/components/ReadingList/ManualReadingListAdder.tsx
@@ -1,0 +1,32 @@
+import { CheckCircleOutlined, CloseCircleOutlined, PlusOutlined } from '@ant-design/icons';
+import { Button, Input } from 'antd';
+import React, { useState } from 'react';
+
+export default function ManualReadingListAdder(): JSX.Element {
+  const [isEditing, setIsEditing] = useState(false);
+  const [title, setTitle] = useState('');
+
+  const submitItem = () => {
+    setTitle('');
+  };
+
+  return (
+    <div className="reading-list-adder">
+      {!isEditing ? (
+        <Button onClick={() => setIsEditing(true)} className="reading-list-adder__startButton">
+          Add to Reading List <PlusOutlined />
+        </Button>
+      ) : (
+        <div className="reading-list-adder__form">
+          <Input placeholder="Paper title" value={title} onChange={(e) => setTitle(e.target.value)} />
+          <Button onClick={submitItem} disabled={title === ''}>
+            <CheckCircleOutlined />
+          </Button>
+          <Button danger onClick={() => setIsEditing(false)}>
+            <CloseCircleOutlined />
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/ReadingList/ReadingList-redux.tsx
+++ b/client/src/components/ReadingList/ReadingList-redux.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import axios from 'axios';
 import arrayMove from 'array-move';
 import { SortEndHandler } from 'react-sortable-hoc';
 import ReadingListContainer from './ReadingList-container';
@@ -8,23 +7,12 @@ import { blankNotes } from '../../templates';
 import { updateDraftId } from '../../slices/activeDraftSlice';
 import { setActiveReview } from '../../slices/activeReviewSlice';
 import { useAppDispatch, useAppSelector } from '../../hooks/reduxHooks';
-import { updateReadingList } from '../../slices/readingListSlice';
+import { useUpdateReadingListFunc } from './hooks';
 
 export default function ReadingListRedux(): JSX.Element {
   const dispatch = useAppDispatch();
   const readingList: Paper[] = useAppSelector((state) => state.readingList);
-  const { demoMode } = useAppSelector((state) => state.auth);
-
-  const updateReadingListFunc = async (newReadingList: Paper[]) => {
-    dispatch(updateReadingList(newReadingList));
-
-    // If we're in demoMode, don't attempt to update the server...
-    if (demoMode) {
-      return;
-    }
-    const { data } = await axios.put<Paper[]>('api/readingList', newReadingList);
-    dispatch(updateReadingList(data));
-  };
+  const { updateReadingListFunc } = useUpdateReadingListFunc();
 
   const handleEditClick = (paper: Paper) => {
     dispatch(updateDraftId(null));

--- a/client/src/components/ReadingList/ReadingList-redux.tsx
+++ b/client/src/components/ReadingList/ReadingList-redux.tsx
@@ -7,12 +7,12 @@ import { blankNotes } from '../../templates';
 import { updateDraftId } from '../../slices/activeDraftSlice';
 import { setActiveReview } from '../../slices/activeReviewSlice';
 import { useAppDispatch, useAppSelector } from '../../hooks/reduxHooks';
-import { useUpdateReadingListFunc } from './hooks';
+import { useSetReadingList } from './hooks';
 
 export default function ReadingListRedux(): JSX.Element {
   const dispatch = useAppDispatch();
   const readingList: Paper[] = useAppSelector((state) => state.readingList);
-  const { updateReadingListFunc } = useUpdateReadingListFunc();
+  const { setReadingList } = useSetReadingList();
 
   const handleEditClick = (paper: Paper) => {
     dispatch(updateDraftId(null));
@@ -22,12 +22,12 @@ export default function ReadingListRedux(): JSX.Element {
 
   const onSortEnd: SortEndHandler = ({ oldIndex, newIndex }) => {
     const newReadingList = arrayMove(readingList, oldIndex, newIndex);
-    updateReadingListFunc(newReadingList);
+    setReadingList(newReadingList);
   };
 
   const removeFromReadingList = (paper: Paper) => {
     const newReadingList = readingList.filter((currPaper) => currPaper !== paper);
-    updateReadingListFunc(newReadingList);
+    setReadingList(newReadingList);
   };
 
   return (

--- a/client/src/components/ReadingList/ReadingList-view.tsx
+++ b/client/src/components/ReadingList/ReadingList-view.tsx
@@ -11,9 +11,7 @@ import { Paper } from '../../types';
 const LIST_HEIGHT = 340;
 const TITLE_CUTOFF = 100;
 
-const DragHandle = SortableHandle(() => (
-  <MenuOutlined style={{ fontSize: '14pt', marginBottom: '5px', marginRight: '15px' }} />
-));
+const DragHandle = SortableHandle(() => <MenuOutlined className="reading-list__item-handle" />);
 
 type SortableItemProps = Pick<ReadingListViewProps, 'handleDeleteClick' | 'handleEditClick'> & {
   value: Paper;
@@ -24,15 +22,7 @@ const SortableItem = SortableElement(({ value, handleEditClick, handleDeleteClic
   <List.Item>
     <div className="reading-list__item">
       <DragHandle />
-      <div
-        style={{
-          display: 'flex',
-          height: '100%',
-          width: '100%',
-          justifyContent: 'space-between',
-          overflow: 'auto',
-        }}
-      >
+      <div className="reading-list__item-container">
         <div>
           <List.Item.Meta
             title={shortenString(value.title, TITLE_CUTOFF)}
@@ -40,7 +30,7 @@ const SortableItem = SortableElement(({ value, handleEditClick, handleDeleteClic
           />
         </div>
         <div>
-          <div className="reading-list__form-button">
+          <div className="reading-list__item-button">
             <Link to="/form">
               <Button onClick={() => handleEditClick(value)} icon={<FormOutlined />} />
             </Link>

--- a/client/src/components/ReadingList/ReadingList-view.tsx
+++ b/client/src/components/ReadingList/ReadingList-view.tsx
@@ -103,7 +103,6 @@ export default function ReadingListView({
     <div className="reading-list">
       <PageHeader title="Reading List" avatar={{ icon: <OrderedListOutlined /> }} />
       {items.length > 0 ? sortableList : noList}
-      <hr />
       <ManualReadingListAdder />
     </div>
   );

--- a/client/src/components/ReadingList/ReadingList-view.tsx
+++ b/client/src/components/ReadingList/ReadingList-view.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { Button, Empty, List, PageHeader } from 'antd';
-import { OrderedListOutlined, DeleteOutlined, FormOutlined, MenuOutlined } from '@ant-design/icons';
+import { OrderedListOutlined, DeleteOutlined, FormOutlined, MenuOutlined, PlusCircleOutlined } from '@ant-design/icons';
 import { SortableContainer, SortableElement, SortableHandle, SortEndHandler } from 'react-sortable-hoc';
 import moment from 'moment';
 import { shortenAuthors, shortenString } from '../utils';
 import './ReadingList.scss';
 import { Paper } from '../../types';
+import ManualReadingListAdder from './ManualReadingListAdder';
 
 const LIST_HEIGHT = 340;
 const TITLE_CUTOFF = 100;
@@ -95,6 +96,8 @@ export default function ReadingListView({
     <div className="reading-list">
       <PageHeader title="Reading List" avatar={{ icon: <OrderedListOutlined /> }} />
       {items.length > 0 ? sortableList : noList}
+      <hr />
+      <ManualReadingListAdder />
     </div>
   );
 }

--- a/client/src/components/ReadingList/ReadingList-view.tsx
+++ b/client/src/components/ReadingList/ReadingList-view.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { Button, Empty, List, PageHeader } from 'antd';
-import { OrderedListOutlined, DeleteOutlined, FormOutlined, MenuOutlined, PlusCircleOutlined } from '@ant-design/icons';
+import { OrderedListOutlined, DeleteOutlined, FormOutlined, MenuOutlined } from '@ant-design/icons';
 import { SortableContainer, SortableElement, SortableHandle, SortEndHandler } from 'react-sortable-hoc';
 import moment from 'moment';
-import { shortenAuthors, shortenString } from '../utils';
+import { shortenAuthors, shortenString, stringArrayHasNonEmpty } from '../utils';
 import './ReadingList.scss';
 import { Paper } from '../../types';
 import ManualReadingListAdder from './ManualReadingListAdder';
+import NAText from '../NAText';
 
 const LIST_HEIGHT = 340;
 const TITLE_CUTOFF = 100;
@@ -27,7 +28,13 @@ const SortableItem = SortableElement(({ value, handleEditClick, handleDeleteClic
         <div>
           <List.Item.Meta
             title={shortenString(value.title, TITLE_CUTOFF)}
-            description={`${shortenAuthors(value.authors)}, ${moment(value.date, 'YYYY-MM').format('YYYY')}`}
+            description={
+              stringArrayHasNonEmpty(value.authors) ? (
+                `${shortenAuthors(value.authors)}, ${moment(value.date, 'YYYY-MM').format('YYYY')}`
+              ) : (
+                <NAText />
+              )
+            }
           />
         </div>
         <div>

--- a/client/src/components/ReadingList/ReadingList.scss
+++ b/client/src/components/ReadingList/ReadingList.scss
@@ -37,8 +37,19 @@
   &__form {
     display: flex;
     justify-content: right;
-    button {
+
+    .ant-btn {
       margin-left: 5px;
+      &[disabled] {
+        &:hover {
+          color: #999 !important;
+          border: 1px solid #d9d9d9 !important;
+          background: none;
+          color: rgba(0, 0, 0, 0.25) !important;
+        }
+        background: none;
+        cursor: not-allowed;
+      }
     }
   }
 }

--- a/client/src/components/ReadingList/ReadingList.scss
+++ b/client/src/components/ReadingList/ReadingList.scss
@@ -42,6 +42,8 @@
 
     .ant-btn {
       margin-left: 5px;
+
+      // override antd allowing disabled buttons to still have hover effects
       &[disabled] {
         &:hover {
           color: #999 !important;

--- a/client/src/components/ReadingList/ReadingList.scss
+++ b/client/src/components/ReadingList/ReadingList.scss
@@ -3,10 +3,24 @@
     display: inline-flex;
     align-items: center;
     width: 100%;
-  }
 
-  &__form-button {
-    padding-bottom: 4px;
+    &-container {
+      display: flex;
+      height: 100%;
+      width: 100%;
+      justify-content: space-between;
+      overflow: auto;
+    }
+
+    &-button {
+      padding-bottom: 4px;
+    }
+
+    &-handle {
+      font-size: 14pt;
+      margin-bottom: 5px;
+      margin-right: 15px;
+    }
   }
 
   .empty-list {

--- a/client/src/components/ReadingList/ReadingList.scss
+++ b/client/src/components/ReadingList/ReadingList.scss
@@ -31,6 +31,8 @@
 }
 
 .reading-list-adder {
+  margin-top: 5px;
+
   &__startButton {
     float: right;
   }

--- a/client/src/components/ReadingList/ReadingList.scss
+++ b/client/src/components/ReadingList/ReadingList.scss
@@ -30,6 +30,19 @@
   }
 }
 
+.reading-list-adder {
+  &__startButton {
+    float: right;
+  }
+  &__form {
+    display: flex;
+    justify-content: right;
+    button {
+      margin-left: 5px;
+    }
+  }
+}
+
 // When dragging, these are outside the .reading-list parent class,
 // so declare these styles here
 .ant-list-item-meta-content {

--- a/client/src/components/ReadingList/ReadingList.test.tsx
+++ b/client/src/components/ReadingList/ReadingList.test.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import Home from '.';
+import { blankPaper, blankUser, demoUser } from '../../templates';
+import { getBlankInitialState, renderWithRouterRedux } from '../../testUtils/reduxRender';
+import { RootState } from '../../store';
+import { ReadingListState } from '../../slices/readingListSlice';
+import ReadingList from '.';
+
+describe('<ReadingList />', () => {
+  const readingList: ReadingListState = [];
+  const initialState: RootState = { ...getBlankInitialState(), readingList };
+
+  it('shows the option to add a manual entry', () => {
+    renderWithRouterRedux(<ReadingList />, { initialState });
+    expect(screen.getByText(/Add to Reading List/)).toBeInTheDocument();
+  });
+
+  describe('when the user clicks the manual add button', () => {
+    it('allows papers to be added', async () => {
+      renderWithRouterRedux(<ReadingList />, { initialState });
+      const startButton = screen.getByRole('button');
+      userEvent.click(startButton);
+
+      // wait for Input to appear
+      await screen.findByPlaceholderText('Paper title');
+
+      // type in a title
+      userEvent.type(screen.getByPlaceholderText('Paper title'), 'Everything about giraffes');
+
+      // click the accept button
+      const acceptButton = screen.getByRole('button', { name: 'check-circle' });
+      userEvent.click(acceptButton);
+
+      // see that our paper made it in
+      expect(screen.getByText(/giraffes/)).toBeInTheDocument();
+    });
+
+    it('allows you to bail out', async () => {
+      renderWithRouterRedux(<ReadingList />, { initialState });
+      const startButton = screen.getByRole('button');
+      userEvent.click(startButton);
+
+      // wait for Input to appear
+      await screen.findByPlaceholderText('Paper title');
+
+      // type in a title
+      userEvent.type(screen.getByPlaceholderText('Paper title'), 'Everything about giraffes');
+
+      // click the cancel button
+      const cancelButton = screen.getByRole('button', { name: 'close-circle' });
+      userEvent.click(cancelButton);
+
+      // see that our paper did not make it in
+      expect(screen.queryByText(/giraffes/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('when there are no papers in the reading list', () => {
+    it('prompts the user to add some', () => {
+      renderWithRouterRedux(<ReadingList />, { initialState });
+      expect(screen.getByText(/Add papers to your reading list/)).toBeInTheDocument();
+    });
+  });
+
+  describe('when there is a paper in the reading list', () => {
+    describe('and the authors are listed', () => {
+      const readingList: ReadingListState = [
+        {
+          ...blankPaper,
+          title:
+            'The wonderful world of potatoes, their colors, their feelings, and how to approach discussions of starchiness',
+          authors: ['Geoff Taylor', 'Marisa Nuzzi'],
+        },
+      ];
+      const initialState: RootState = { ...getBlankInitialState(), readingList };
+      it('displays the start of the paper title', () => {
+        renderWithRouterRedux(<ReadingList />, { initialState });
+        expect(screen.getByText(/The wonderful world/)).toBeInTheDocument();
+      });
+
+      it('does not display the end of the paper title', () => {
+        renderWithRouterRedux(<ReadingList />, { initialState });
+        expect(screen.queryByText(/starchiness/)).not.toBeInTheDocument();
+      });
+
+      it('shows author last names', () => {
+        renderWithRouterRedux(<ReadingList />, { initialState });
+        expect(screen.getByText(/Taylor/)).toBeInTheDocument();
+        expect(screen.queryByText(/Geoff/)).not.toBeInTheDocument();
+      });
+    });
+
+    describe('and there are no authors', () => {
+      const readingList: ReadingListState = [
+        {
+          ...blankPaper,
+          title:
+            'The wonderful world of potatoes, their colors, their feelings, and how to approach discussions of starchiness',
+          authors: [],
+        },
+      ];
+      const initialState: RootState = { ...getBlankInitialState(), readingList };
+      it('says N/A', () => {
+        renderWithRouterRedux(<ReadingList />, { initialState });
+        expect(screen.getByText(/N\/A/)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('when there are no papers in the reading list', () => {
+    const readingList: ReadingListState = [];
+    const initialState: RootState = { ...getBlankInitialState(), readingList };
+
+    it('prompts the user to add some', () => {
+      renderWithRouterRedux(<ReadingList />, { initialState });
+      expect(screen.getByText(/Add papers to your reading list/)).toBeInTheDocument();
+    });
+  });
+});

--- a/client/src/components/ReadingList/ReadingList.test.tsx
+++ b/client/src/components/ReadingList/ReadingList.test.tsx
@@ -30,7 +30,7 @@ describe('<ReadingList />', () => {
       userEvent.type(screen.getByPlaceholderText('Paper title'), 'Everything about giraffes');
 
       // click the accept button
-      const acceptButton = screen.getByRole('button', { name: 'check-circle' });
+      const acceptButton = screen.getByRole('button', { name: 'submit' });
       userEvent.click(acceptButton);
 
       // see that our paper made it in
@@ -49,7 +49,7 @@ describe('<ReadingList />', () => {
       userEvent.type(screen.getByPlaceholderText('Paper title'), 'Everything about giraffes');
 
       // click the cancel button
-      const cancelButton = screen.getByRole('button', { name: 'close-circle' });
+      const cancelButton = screen.getByRole('button', { name: 'cancel' });
       userEvent.click(cancelButton);
 
       // see that our paper did not make it in

--- a/client/src/components/ReadingList/ReadingList.test.tsx
+++ b/client/src/components/ReadingList/ReadingList.test.tsx
@@ -18,7 +18,7 @@ describe('<ReadingList />', () => {
   });
 
   describe('when the user clicks the manual add button', () => {
-    it('allows papers to be added', async () => {
+    beforeEach(async () => {
       renderWithRouterRedux(<ReadingList />, { initialState });
       const startButton = screen.getByRole('button');
       userEvent.click(startButton);
@@ -28,7 +28,9 @@ describe('<ReadingList />', () => {
 
       // type in a title
       userEvent.type(screen.getByPlaceholderText('Paper title'), 'Everything about giraffes');
+    });
 
+    it('allows papers to be added', async () => {
       // click the accept button
       const acceptButton = screen.getByRole('button', { name: 'submit' });
       userEvent.click(acceptButton);
@@ -38,16 +40,6 @@ describe('<ReadingList />', () => {
     });
 
     it('allows you to bail out', async () => {
-      renderWithRouterRedux(<ReadingList />, { initialState });
-      const startButton = screen.getByRole('button');
-      userEvent.click(startButton);
-
-      // wait for Input to appear
-      await screen.findByPlaceholderText('Paper title');
-
-      // type in a title
-      userEvent.type(screen.getByPlaceholderText('Paper title'), 'Everything about giraffes');
-
       // click the cancel button
       const cancelButton = screen.getByRole('button', { name: 'cancel' });
       userEvent.click(cancelButton);

--- a/client/src/components/ReadingList/ReadingList.test.tsx
+++ b/client/src/components/ReadingList/ReadingList.test.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import Home from '.';
-import { blankPaper, blankUser, demoUser } from '../../templates';
+import { blankPaper } from '../../templates';
 import { getBlankInitialState, renderWithRouterRedux } from '../../testUtils/reduxRender';
 import { RootState } from '../../store';
 import { ReadingListState } from '../../slices/readingListSlice';

--- a/client/src/components/ReadingList/hooks.ts
+++ b/client/src/components/ReadingList/hooks.ts
@@ -5,14 +5,14 @@ import { updateReadingList } from '../../slices/readingListSlice';
 import { constructPaperFromResponse, PaperResponse } from '../../dtos';
 
 interface returnProps {
-  updateReadingListFunc: (newReadingList: Paper[]) => Promise<void>;
+  setReadingList: (newReadingList: Paper[]) => Promise<void>;
 }
 
-export const useUpdateReadingListFunc = (): returnProps => {
+export const useSetReadingList = (): returnProps => {
   const dispatch = useAppDispatch();
   const { demoMode } = useAppSelector((state) => state.auth);
 
-  const updateReadingListFunc = async (newReadingList: Paper[]) => {
+  const setReadingList = async (newReadingList: Paper[]) => {
     dispatch(updateReadingList(newReadingList));
 
     // If we're in demoMode, don't attempt to update the server...
@@ -24,5 +24,5 @@ export const useUpdateReadingListFunc = (): returnProps => {
       dispatch(updateReadingList(data.map(constructPaperFromResponse)));
     }
   };
-  return { updateReadingListFunc };
+  return { setReadingList };
 };

--- a/client/src/components/ReadingList/hooks.ts
+++ b/client/src/components/ReadingList/hooks.ts
@@ -1,0 +1,28 @@
+import axios from 'axios';
+import { Paper } from '../../types';
+import { useAppDispatch, useAppSelector } from '../../hooks/reduxHooks';
+import { updateReadingList } from '../../slices/readingListSlice';
+import { constructPaperFromResponse, PaperResponse } from '../../dtos';
+
+interface returnProps {
+  updateReadingListFunc: (newReadingList: Paper[]) => Promise<void>;
+}
+
+export const useUpdateReadingListFunc = (): returnProps => {
+  const dispatch = useAppDispatch();
+  const { demoMode } = useAppSelector((state) => state.auth);
+
+  const updateReadingListFunc = async (newReadingList: Paper[]) => {
+    dispatch(updateReadingList(newReadingList));
+
+    // If we're in demoMode, don't attempt to update the server...
+    if (demoMode) {
+      return;
+    }
+    const { data } = await axios.put<PaperResponse[]>('api/readingList', newReadingList);
+    if (data) {
+      dispatch(updateReadingList(data.map(constructPaperFromResponse)));
+    }
+  };
+  return { updateReadingListFunc };
+};

--- a/client/src/components/utils.tsx
+++ b/client/src/components/utils.tsx
@@ -65,7 +65,7 @@ export const removeMiddleAuthors = (authorList: string[], numKeepEitherEnd: numb
 };
 
 export const shortenAuthors = (authors: string[]): JSX.Element | string => {
-  if (!authors.length) return <NAText />;
+  if (!authors.length || !stringArrayHasNonEmpty(authors)) return <NAText />;
 
   let authorString = '';
 

--- a/client/src/slices/readingListSlice.ts
+++ b/client/src/slices/readingListSlice.ts
@@ -3,8 +3,8 @@ import { enterDemoMode, fetchUser } from '../actions';
 import { demoUser } from '../templates';
 import { Paper } from '../types';
 
-export type ReadlingListState = Paper[];
-const initialState: ReadlingListState = [];
+export type ReadingListState = Paper[];
+const initialState: ReadingListState = [];
 
 export const readingListSlice = createSlice({
   name: 'readingList',


### PR DESCRIPTION
A long awaited feature arrives!

Users can now add papers to the reading list manually. For simplicity, only the title can be set. Authors and other `Paper` fields need to be filled in manually.

This also adds what are essentially some integration tests to the `ReadingList` component, which was only sparsely tested before (its existence was tested in the tests of the `Home` component).